### PR TITLE
Fix the regex to be a little more flexible and accept docker/k8s internal DNS

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -41,7 +41,7 @@ def main():
     server = require_env("BW_SERVER")
     if (
         re.match(
-            r"^(?:https?://)?(?:[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}|(?:\d{1,3}\.){3}\d{1,3}|localhost)(:\d+)?(/[a-zA-Z0-9\-\._~/]*)?$",
+            r"^(?:https?://)?(?:[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}|(?:\d{1,3}\.){3}\d{1,3}|\w+)(:\d+)?(/[a-zA-Z0-9\-\._~/]*)?$",
             server,
         )
         is None


### PR DESCRIPTION
Last update broke paths that used single-word addresses on the server URL, effectively breaking internal DNS for docker/k8s

This fixes it with an update to the regex