### PR TITLE
feat: clarify setup completion page

### DIFF
--- a/src/init.py
+++ b/src/init.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, Form
 from fastapi.responses import HTMLResponse, RedirectResponse, FileResponse
 from src.db import db_connect, put_key
 from src.utils import validate_path
+from html import escape
 import logging
 from sys import stdout
 from threading import Thread
@@ -71,6 +72,7 @@ def done() -> str:
         os.kill(os.getpid(), signal.SIGTERM)
 
     Thread(target=_shutdown).start()
+    escaped_data_dir = escape(DATA_DIR)
     return f"""
     <html>
     <body style="background:#111; color:#eee; display:flex; justify-content:center; align-items:center; min-height:100vh; font-family:Segoe UI, sans-serif; margin:0;">
@@ -78,7 +80,7 @@ def done() -> str:
         <h3>Setup complete.</h3>
         <p>Your credentials were saved and BackVault is switching into normal backup mode.</p>
         <p>This setup UI only runs for the first configuration. After this page closes, use the container logs to confirm backup activity.</p>
-        <p>Backups will be written under <code>{DATA_DIR}</code> unless you configured another data directory.</p>
+        <p>Backups will be written under <code>{escaped_data_dir}</code> unless you configured another data directory.</p>
         <p>You can close this window.</p>
       </div>
     </body>

--- a/src/init.py
+++ b/src/init.py
@@ -71,12 +71,15 @@ def done() -> str:
         os.kill(os.getpid(), signal.SIGTERM)
 
     Thread(target=_shutdown).start()
-    return """
+    return f"""
     <html>
-    <body style="background:#111; color:#eee; display:flex; justify-content:center; align-items:center; height:100vh; font-family:Segoe UI, sans-serif;">
-      <div style="text-align:center;">
+    <body style="background:#111; color:#eee; display:flex; justify-content:center; align-items:center; min-height:100vh; font-family:Segoe UI, sans-serif; margin:0;">
+      <div style="max-width:520px; padding:32px; text-align:left; line-height:1.5;">
         <h3>Setup complete.</h3>
-        <p>The UI will now stop and the container will enter normal mode. You can close this window.</p>
+        <p>Your credentials were saved and BackVault is switching into normal backup mode.</p>
+        <p>This setup UI only runs for the first configuration. After this page closes, use the container logs to confirm backup activity.</p>
+        <p>Backups will be written under <code>{DATA_DIR}</code> unless you configured another data directory.</p>
+        <p>You can close this window.</p>
       </div>
     </body>
     </html>

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,5 @@
 from fastapi.testclient import TestClient
-from src.init import app, DB_PATH, PRAGMA_KEY_FILE
+from src.init import app, DATA_DIR, DB_PATH, PRAGMA_KEY_FILE
 from unittest.mock import patch, MagicMock
 
 client = TestClient(app)
@@ -84,5 +84,6 @@ def test_done_endpoint(mock_sleep, mock_kill):
     assert "switching into normal backup mode" in response.text
     assert "only runs for the first configuration" in response.text
     assert "Backups will be written under" in response.text
+    assert f"<code>{DATA_DIR}</code>" in response.text
     mock_sleep.assert_called_once_with(2)
     mock_kill.assert_called_once()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -81,5 +81,8 @@ def test_done_endpoint(mock_sleep, mock_kill):
     response = client.get("/done")
     assert response.status_code == 200
     assert "<h3>Setup complete.</h3>" in response.text
+    assert "switching into normal backup mode" in response.text
+    assert "only runs for the first configuration" in response.text
+    assert "Backups will be written under" in response.text
     mock_sleep.assert_called_once_with(2)
     mock_kill.assert_called_once()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,3 +1,4 @@
+from html import escape
 from fastapi.testclient import TestClient
 from src.init import app, DATA_DIR, DB_PATH, PRAGMA_KEY_FILE
 from unittest.mock import patch, MagicMock
@@ -84,6 +85,6 @@ def test_done_endpoint(mock_sleep, mock_kill):
     assert "switching into normal backup mode" in response.text
     assert "only runs for the first configuration" in response.text
     assert "Backups will be written under" in response.text
-    assert f"<code>{DATA_DIR}</code>" in response.text
+    assert f"<code>{escape(DATA_DIR)}</code>" in response.text
     mock_sleep.assert_called_once_with(2)
     mock_kill.assert_called_once()


### PR DESCRIPTION
Closes #25

This makes the final setup page less abrupt by confirming that credentials were saved, explaining that the setup UI is only for first configuration, and showing where backups are written by default.

Checks:
- `git diff --check`
- `python3 -m py_compile src/init.py tests/test_init.py`

I could not run `python3 -m pytest tests/test_init.py` locally because `pytest` is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Updated the setup completion (`/done`) page to explicitly confirm credentials were saved and the app is switching to normal backup mode
- Clarified that the web-based setup UI is only for initial configuration and won’t be available for later operations
- Added guidance showing the default backup destination (`DATA_DIR`) on the completion page
- Extended tests to assert the completion page renders the actual `DATA_DIR` value in the HTML

| Author | Lines Added | Lines Removed |
|---|---:|---:|
| rupayon123 | 175 | 0 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the setup completion page by adding informative messaging and addressing the two issues raised in the previous review round — HTML-escaping `DATA_DIR` before embedding it in the response and asserting the escaped value in the test.

- `src/init.py`: wraps `DATA_DIR` with `html.escape` before interpolation, and expands the completion page copy to confirm credentials were saved, note that the setup UI is one-time only, and display the default backup directory.
- `tests/test_init.py`: imports `DATA_DIR` and adds four new assertions, including `f"<code>{escape(DATA_DIR)}</code>" in response.text`, which closes the gap from the prior review.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a small, self-contained UI copy update with correct HTML escaping and matching test coverage.

Both issues from the previous review (unescaped path interpolation and missing DATA_DIR assertion in the test) are now properly addressed. validate_path already returns a plain str, so html.escape receives the right type. No new logic paths are introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/init.py | Adds html.escape for DATA_DIR before HTML interpolation and expands completion page copy; both previously raised issues are now resolved. |
| tests/test_init.py | Adds four new assertions to test_done_endpoint, including a check that the escaped DATA_DIR value is present in the rendered HTML. |

</details>

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as Browser
    participant F as FastAPI (/done)
    participant T as Shutdown Thread

    U->>F: GET /done
    F->>F: escape(DATA_DIR)
    F->>T: Thread(_shutdown).start()
    F-->>U: 200 HTML (setup complete, DATA_DIR shown)
    T->>T: time.sleep(2)
    T->>F: os.kill(pid, SIGTERM)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as Browser
    participant F as FastAPI (/done)
    participant T as Shutdown Thread

    U->>F: GET /done
    F->>F: escape(DATA_DIR)
    F->>T: Thread(_shutdown).start()
    F-->>U: 200 HTML (setup complete, DATA_DIR shown)
    T->>T: time.sleep(2)
    T->>F: os.kill(pid, SIGTERM)
```

</a>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into ui-done-page-gu..."](https://github.com/mvfc/backvault/commit/258c63cabaf949a49888db658832831626b3fe41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37442214)</sub>

<!-- /greptile_comment -->