### PR TITLE
Update ssl dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ db/
 trivy
 *bandit*
 .pre-commit*
+bin/act

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk update && apk add --no-cache \
     bash \
     unzip \
     sqlcipher \
-    libressl-dev \
+    openssl-dev \
     sqlite-dev \
     sqlcipher-dev \
     build-base \
@@ -74,7 +74,7 @@ RUN chmod +x /app/entrypoint.sh /app/cleanup.sh /app/run.sh
 RUN pip install --upgrade pip --no-cache-dir && \
     pip install --no-input --no-cache-dir -r requirements.txt
 
-RUN apk del curl unzip binutils npm coreutils build-base libffi-dev cargo python3-dev --no-cache && \
+RUN apk del curl unzip binutils npm coreutils build-base libffi-dev cargo python3-dev openssl-dev --no-cache && \
     rm -rf /var/lib/apk/*
 
 ENV PYTHONPATH=/app


### PR DESCRIPTION
change from libressl-dev to openssl-dev for more compatible alpine image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Update Alpine SSL build dependencies: replace `libressl-dev` with `openssl-dev` in the Dockerfile
- Adjust the build dependency cleanup step to remove `openssl-dev` (avoiding leftover build packages)
- Prevent committing a local runner tool by adding `bin/act` to `.gitignore`

## Contribution Summary

| Author | Lines Added | Lines Removed |
|---|---:|---:|
| Matheus Cunha | 98 | 0 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces `libressl-dev` with `openssl-dev` in the Alpine build stage and also removes `openssl-dev` in the cleanup step — an improvement over the original, which never deleted `libressl-dev` after building. The `.gitignore` is updated to exclude `bin/act`, addressing a pre-existing comment about the committed binary.

- **Dockerfile**: Swap `libressl-dev` → `openssl-dev` in `apk add`, and explicitly remove `openssl-dev` in the `apk del` cleanup step to trim image size.
- **.gitignore**: Add `bin/act` so the locally-installed `act` binary is no longer tracked by git.

<h3>Confidence Score: 5/5</h3>

Straightforward, low-risk package swap with no functional side-effects — safe to merge.

The change swaps one Alpine crypto dev package for another (libressl-dev → openssl-dev), which is the correct move for modern Alpine images that ship OpenSSL by default. The runtime openssl library is retained at container start because sqlcipher depends on it, so removing openssl-dev in the cleanup step won't break anything. No logic, scripts, or application code are affected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Dockerfile | Replace libressl-dev with openssl-dev in apk add, and add openssl-dev to the cleanup apk del step; both changes are correct and improve Alpine compatibility and image hygiene. |
| .gitignore | Adds bin/act to .gitignore to stop tracking the locally-installed act binary, resolving the previously flagged binary-in-source-control issue. |

</details>


</details>


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["FROM python:3.13-alpine"] --> B["apk add --no-cache\n+ openssl-dev ✅ (was libressl-dev)"]
    B --> C["apk upgrade -a"]
    C --> D["adduser / addgroup"]
    D --> E["npm install -g @bitwarden/cli"]
    E --> F["curl supercronic binary + sha1 verify"]
    F --> G["COPY src, scripts, requirements"]
    G --> H["pip install -r requirements.txt\n(compiles native extensions against openssl-dev)"]
    H --> I["apk del build tools\n+ openssl-dev ✅ (newly removed)"]
    I --> J["Final image\n(openssl runtime kept via sqlcipher dep)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["FROM python:3.13-alpine"] --> B["apk add --no-cache\n+ openssl-dev ✅ (was libressl-dev)"]
    B --> C["apk upgrade -a"]
    C --> D["adduser / addgroup"]
    D --> E["npm install -g @bitwarden/cli"]
    E --> F["curl supercronic binary + sha1 verify"]
    F --> G["COPY src, scripts, requirements"]
    G --> H["pip install -r requirements.txt\n(compiles native extensions against openssl-dev)"]
    H --> I["apk del build tools\n+ openssl-dev ✅ (newly removed)"]
    I --> J["Final image\n(openssl runtime kept via sqlcipher dep)"]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `bin/act`, line 1 ([link](https://github.com/mvfc/backvault/blob/46811da676fa28f733f2ffe1d3e6867fb255d1b8/bin/act#L1)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Binary executable committed to source control**

   A 21 MB statically-linked ELF x86-64 binary has been added to the repository. Committing compiled binaries directly inflates `git clone` size permanently (git history stores the full blob), makes the binary opaque to code review, and is architecture-specific — it will not work on `arm64`/`armv7` hosts even though the Dockerfile's `supercronic` install already supports those targets. The `act` CLI is installable via `brew install act`, its own install script, or a pinned GitHub Release download with checksum verification; it does not need to live in the repo. Adding `bin/act` to `.gitignore` and documenting the install step in the README is the standard approach.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: bin/act
   Line: 1

   Comment:
   **Binary executable committed to source control**

   A 21 MB statically-linked ELF x86-64 binary has been added to the repository. Committing compiled binaries directly inflates `git clone` size permanently (git history stores the full blob), makes the binary opaque to code review, and is architecture-specific — it will not work on `arm64`/`armv7` hosts even though the Dockerfile's `supercronic` install already supports those targets. The `act` CLI is installable via `brew install act`, its own install script, or a pinned GitHub Release download with checksum verification; it does not need to live in the repo. Adding `bin/act` to `.gitignore` and documenting the install step in the README is the standard approach.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["add bin/act to gitignore"](https://github.com/mvfc/backvault/commit/fadc737c153bb2f7ea0278d5eca93dcff37eca08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38398501)</sub>

<!-- /greptile_comment -->